### PR TITLE
fix reading random data from the stack

### DIFF
--- a/src/lua_net.h
+++ b/src/lua_net.h
@@ -161,7 +161,7 @@ int icelua_fn_common_net_pack(lua_State *L)
 				*(s++) = (xint>>8) & 0xFF;
 				*(s++) = (xint>>16) & 0xFF;
 				*(s++) = (xint>>24) & 0xFF;
-				xint = ((int *)(float *)&xdouble)[4];
+				xint = ((int *)(float *)&xdouble)[1];
 				*(s++) = xint & 0xFF;
 				*(s++) = (xint>>8) & 0xFF;
 				*(s++) = (xint>>16) & 0xFF;


### PR DESCRIPTION
compiler takes sizeof(float*) into account already when doing pointer
indexing (unless someone meant to read random data from the stack)
