### PR TITLE
[OpenGL] optimized rendering (map split in chunks, only chunks around camera are rendered)

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -19,7 +19,7 @@
 #define VERSION_X 0
 #define VERSION_Y 0
 #define VERSION_A 0
-#define VERSION_Z 37
+#define VERSION_Z 38
 // Remember to bump "Z" basically every time you change the engine!
 // Remember to bump the version in Lua too!
 // Remember to document API changes in a new version!
@@ -297,16 +297,30 @@ feel free to store it in the "invisible" parts.
 
 */
 
+#ifdef USE_OPENGL
+typedef struct map_chunk
+{
+	GLuint vbo;
+	int vbo_dirty;
+	int vbo_arr_len, vbo_arr_max;
+	int cx, cz;
+	float *vbo_arr;
+} map_chunk_t;
+#endif
+
 typedef struct map
 {
 	int udtype;
 	int xlen, ylen, zlen;
 #ifdef USE_OPENGL
-	GLuint vbo;
-	int vbo_dirty;
-	float *vbo_arr;
-	int vbo_arr_len, vbo_arr_max;
-	int vbo_cx, vbo_cz;
+	/* circular array of visible map chunks */
+	map_chunk_t *visible_chunks_arr;
+	/* current virtual center position in the circular array */
+	int visible_chunks_vcenter_x;
+	int visible_chunks_vcenter_z;
+	/* current virtual center chunk coordinates in the circular array */
+	int visible_chunks_vcenter_cx;
+	int visible_chunks_vcenter_cz;
 #endif
 	uint8_t **pillars;
 	// TODO ? heap allocator ?
@@ -504,6 +518,12 @@ void render_blit_img(uint32_t *pixels, int width, int height, int pitch,
 	img_t *src, int dx, int dy, int bw, int bh, int sx, int sy, uint32_t color);
 int render_init(int width, int height);
 void render_deinit(void);
+#ifdef USE_OPENGL
+void render_init_visible_chunks(map_t *map, int starting_chunk_coordinate_x, int starting_chunk_coordinate_z);
+void render_map_mark_chunks_as_dirty(map_t *map, int pillar_x, int pillar_z);
+void render_free_visible_chunks(map_t *map);
+int render_map_visible_chunks_count_dirty(map_t *map);
+#endif
 
 // vecmath.c
 vec4f_t mtx_apply_vec(matrix_t *mtx, vec4f_t *vec);

--- a/pkg/base/version.lua
+++ b/pkg/base/version.lua
@@ -16,9 +16,9 @@
 ]]
 
 VERSION_ENGINE = {
-	cmp={0,0,0,0,37},
-	num=37,
-	str="0.0-37",
+	cmp={0,0,0,0,38},
+	num=38,
+	str="0.0-38",
 }
 
 VERSION_BUGS = {
@@ -57,7 +57,9 @@ VERSION_BUGS = {
 {intro=nil, fix=34, msg="Server must be manually seeded"},
 {intro=33, fix=34, msg="A few compilation warnings that shouldn't be there"},
 {intro=nil, fix=35, msg="[OpenGL] Smooth lighting not supported"},
-{intro=35, fix=36, msg="[OpenGL] Smooth lighting of PMF models not supported"},
+{intro=35, fix=nil, msg="[OpenGL] Smooth lighting of PMF models not supported"},
 {intro=37, fix=nil, msg="[softgm] Preliminary smooth lighting (WIP)"},
+{intro=nil, fix=38, msg="[OpenGL] slow rendering"},
+{intro=38, fix=nil, msg="[OpenGL] optimized rendering (WIP)"},
 }
 

--- a/src/lua_map.h
+++ b/src/lua_map.h
@@ -85,9 +85,8 @@ int icelua_fn_common_map_new(lua_State *L)
 		*(p++) = v; *(p++) = v; *(p++) = v; *(p++) = 1;
 	}
 #ifdef USE_OPENGL
-	map->vbo = 0;
-	map->vbo_dirty = 1;
-	map->vbo_arr = NULL;
+	map->visible_chunks_arr = NULL;
+	render_init_visible_chunks(map, 0, 0);
 #endif
 	
 	lua_pushlightuserdata(L, map);
@@ -327,7 +326,7 @@ int icelua_fn_common_map_pillar_set(lua_State *L)
 	}
 
 #ifdef USE_OPENGL
-	map->vbo_dirty = 1;
+	render_map_mark_chunks_as_dirty(map, px, pz);
 #endif
 	
 	force_redraw = 1;

--- a/src/main.c
+++ b/src/main.c
@@ -204,6 +204,11 @@ int update_client_cont1(void)
 	// skip while still loading
 	if(mod_basedir == NULL || (boot_mode & 8))
 		return 0;
+
+#ifdef USE_OPENGL
+	if (render_map_visible_chunks_count_dirty(clmap) > 0)
+		force_redraw = 1;
+#endif
 	
 	// redraw scene if necessary
 	if(force_redraw

--- a/src/map.c
+++ b/src/map.c
@@ -97,9 +97,8 @@ map_t *map_parse_root(const char *dend, const char *data, int xlen, int ylen, in
 	}
 
 #ifdef USE_OPENGL
-	map->vbo = 0;
-	map->vbo_dirty = 1;
-	map->vbo_arr = NULL;
+	map->visible_chunks_arr = NULL;
+	render_init_visible_chunks(map, 0, 0);
 #endif
 	
 	return map;
@@ -195,9 +194,8 @@ map_t *map_parse_icemap(int len, const char *data)
 	}
 
 #ifdef USE_OPENGL
-	map->vbo = 0;
-	map->vbo_dirty = 1;
-	map->vbo_arr = NULL;
+	map->visible_chunks_arr = NULL;
+	render_init_visible_chunks(map, 0, 0);
 #endif
 	
 	//printf("all good.\n");
@@ -400,10 +398,7 @@ void map_free(map_t *map)
 	if(map->pillars != NULL)
 		free(map->pillars);
 #ifdef USE_OPENGL
-	if(map->vbo != 0)
-		glDeleteBuffers(1, &(map->vbo));
-	if(map->vbo_arr != NULL)
-		free(map->vbo_arr);
+	render_free_visible_chunks(map);
 #endif
 	
 	free(map);


### PR DESCRIPTION
Optimized rendering for OpenGL.

Map is divided in chunks and a circular array is used to store chunks around camera.
Chunks are only rebuilt if needed.

Optional parameters (CHUNK_SIZE, VISIBLE_CHUNKS, CHUNKS_TO_TESSELATE_PER_FRAME) will be added to the json file in the next commit.
