### PR TITLE
Added OS X support

### DIFF
--- a/Makefile.glosx
+++ b/Makefile.glosx
@@ -1,0 +1,30 @@
+# I personally don't care if you steal this makefile. --GM
+
+CC = gcc
+CFLAGS = -pg -O2 -fno-strict-aliasing -g `sdl-config --cflags` -Wall -Wextra \
+	-Wno-unused-variable -Wno-unused-parameter \
+	$(CFLAGS_EXTRA) \
+	-DUSE_OPENGL -DAPPLE \
+	-I $(INCDIR) -Ixlibinc \
+	$(HEADERS_Lua)
+
+# Uncomment this if you are Debian or Debian-derived
+HEADERS_Lua = #-I /usr/include/lua5.1
+
+LDFLAGS = -pg -g $(LDFLAGS_EXTRA) 
+LIBS_SDL = `sdl-config --libs`
+LIBS_ENet = -lenet
+LIBS_Lua = -llua
+# Lua is not an acronym. Get used to typing it with lower case u/a.
+LIBS_zlib = -lz
+LIBS_sackit = -lsackit
+LIBS_gl = -L/System/Library/Frameworks/OpenGL.framework/Libraries -lGL
+LIBS = -Lxlibinc -lm $(LIBS_Lua) $(LIBS_SDL) $(LIBS_zlib) $(LIBS_sackit) $(LIBS_gl) -lGLEW $(LIBS_ENet)
+
+BINNAME = iceball-gl
+RENDERER = gl
+
+OBJDIR = build/osx_gl
+
+include main.make
+

--- a/Makefile.osx
+++ b/Makefile.osx
@@ -1,0 +1,27 @@
+# I personally don't care if you steal this makefile. --GM
+
+CC = gcc
+CFLAGS = -pg -O2 -fno-strict-aliasing -g `sdl-config --cflags` -Wall -Wextra \
+	-Wno-unused-variable -Wno-unused-parameter \
+	$(CFLAGS_EXTRA) \
+	-DAPPLE -fopenmp \
+	-I $(INCDIR) -Ixlibinc \
+	$(HEADERS_Lua)
+
+# Uncomment this if you are Debian or Debian-derived
+HEADERS_Lua = #-I /usr/include/lua5.1
+
+LDFLAGS = -pg -g $(LDFLAGS_EXTRA) -fopenmp
+LIBS_SDL = `sdl-config --libs`
+LIBS_ENet = -lenet
+LIBS_Lua = -llua
+# Lua is not an acronym. Get used to typing it with lower case u/a.
+LIBS_zlib = -lz
+LIBS_sackit = -lsackit
+LIBS = -Lxlibinc -lm $(LIBS_Lua) $(LIBS_SDL) $(LIBS_zlib) $(LIBS_sackit) $(LIBS_ENet)
+
+BINNAME = iceball
+
+OBJDIR = build/osx
+
+include main.make

--- a/include/common.h
+++ b/include/common.h
@@ -43,7 +43,9 @@
 #ifndef _MSC_VER
 #define PACK_START
 #define PACK_END
+#ifndef APPLE
 #include <immintrin.h>
+#endif
 #include <stdint.h>
 #else
 #define __attribute__(x)
@@ -61,6 +63,7 @@ typedef unsigned __int64	uint64_t;
 #define _USE_MATH_DEFINES	//M_PI and whatnot from math.h
 #pragma warning( disable: 4200 4244 4996)
 #endif
+
 #include <omp.h>
 
 #include <string.h>
@@ -156,6 +159,13 @@ enum
 
 // if this flag is set, free when finished sending
 #define UDF_TEMPSEND 0x8000
+
+// hack for apple computers running ancient GCCs
+#ifdef APPLE
+#undef __SSE__
+#undef __SSE2__
+#undef _SSE_
+#endif
 
 #ifdef __SSE__
 __attribute__((aligned(16)))


### PR DESCRIPTION
No SSE support on the softgm renderer - that's because Apple's GCC 4.2 is too ancient to include immintrin.

Use Homebrew and install enet, SDL and lua (default versions are the ones iceball needs, in fact). Install sackit with your own cp magic - compiles automatically. Use new makefiles for iceball. Should work.
