### PR TITLE
Fixed json syntax  in clsave

### DIFF
--- a/clsave/config.json
+++ b/clsave/config.json
@@ -41,7 +41,7 @@
 		"bufsize": 2048,
 		
 		"volume": 1.0
-	}
+	},
 
 	"security" : {
 		"bin_storage_allowed": true,


### PR DESCRIPTION
Don't forget the commas, guy
anyhow, why doesn't this cause an error? it does in python when trying to read from it.
