### PR TITLE
Clean up magic constants and command line parsing

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -29,6 +29,15 @@
 // Remember to document API changes in a new version!
 // Z can only be 0 for official releases!
 
+#define NET_HOST_SIZE 256
+#define NET_PATH_SIZE 256
+
+#define IB_CLIENT 0x1
+#define IB_SERVER 0x2
+#define IB_MAIN_LOADED 0x4
+#define IB_MAIN_LOADING 0x8
+#define IB_ENET 0x10
+
 #define MODEL_BONE_MAX  256
 #define MODEL_POINT_MAX 4096
 #define PACKET_LEN_MAX 2560
@@ -580,10 +589,11 @@ extern int mk_compat_mode;
 extern int force_redraw;
 
 extern int net_port;
-extern char *net_addr;
-extern char net_addr_xbuf[];
-extern int boot_mode;
+extern char *net_address;
+extern char *net_path;
+
 extern char *mod_basedir;
+extern int boot_mode;
 
 extern int main_argc;
 extern char **main_argv;

--- a/src/lua.c
+++ b/src/lua.c
@@ -83,7 +83,7 @@ int icelua_fn_common_mk_compat_disable(lua_State *L)
 #ifndef DEDI
 int icelua_fn_client_mk_sys_execv(lua_State *L)
 {
-	if((boot_mode & 3) != 3 || net_port != 0)
+	if((boot_mode & (IB_CLIENT | IB_SERVER)) != (IB_CLIENT | IB_SERVER) || net_port != 0)
 		return luaL_error(L, "mk_sys_execv called when not in -s 0 mode");
 
 	int top = lua_gettop(L);
@@ -436,9 +436,9 @@ int icelua_initfetch(void)
 	printf("Client loaded! Initialising...\n");
 	for(i = 0; i < argct; i++)
 		lua_pushstring(lstate_client, main_argv[i+main_largstart]);
-	if((boot_mode & 1) && net_addr_xbuf[1] != '\x00')
+	if((boot_mode & IB_CLIENT) && net_path[1] != '\x00')
 	{
-		lua_pushstring(lstate_client, net_addr_xbuf);
+		lua_pushstring(lstate_client, net_path);
 		argct++;
 	}
 	if(lua_pcall(lstate_client, argct, 0, 0) != 0)
@@ -449,7 +449,7 @@ int icelua_initfetch(void)
 	}
 
 	printf("Done!\n");
-	boot_mode |= 4;
+	boot_mode |= IB_MAIN_LOADED;
 
 	return 0;
 }
@@ -504,7 +504,7 @@ int icelua_init(void)
 	int i, argct;
 
 	// create states
-	if(boot_mode & 1)
+	if(boot_mode & IB_CLIENT)
 	{
 		// create temp state for loading config
 		lua_State *Lc = luaL_newstate();
@@ -726,8 +726,8 @@ int icelua_init(void)
 #endif
 	}
 
-	lstate_client = (boot_mode & 1 ? luaL_newstate() : NULL);
-	lstate_server = (boot_mode & 2 ? luaL_newstate() : NULL);
+	lstate_client = (boot_mode & IB_CLIENT ? luaL_newstate() : NULL);
+	lstate_server = (boot_mode & IB_SERVER ? luaL_newstate() : NULL);
 
 	// create tables
 	if(lstate_client != NULL)

--- a/src/lua_fetch.h
+++ b/src/lua_fetch.h
@@ -418,7 +418,7 @@ int icelua_fn_common_fetch_poll(lua_State *L)
 #ifdef DEDI
 	return luaL_error(L, "EDOOFUS: why the hell is this being called in the dedi version?");
 #else
-	if((boot_mode & 4) ? run_game_cont1() : run_game_cont2())
+	if((boot_mode & IB_MAIN_LOADED) ? run_game_cont1() : run_game_cont2())
 		return luaL_error(L, "quit flag asserted!");
 #endif
 

--- a/src/path.c
+++ b/src/path.c
@@ -115,7 +115,7 @@ int path_type_client_writable(int type)
 	return type == PATH_CLSAVE_BASEDIR_VOLATILE
 		|| type == PATH_CLSAVE_VOLATILE
 		|| (type == PATH_CLSAVE_PUBLIC
-			&& (boot_mode & 3) == 3 && net_port == 0);
+			&& (boot_mode & (IB_CLIENT | IB_SERVER)) == (IB_CLIENT | IB_SERVER) && net_port == 0);
 }
 
 int path_type_server_readable(int type)


### PR DESCRIPTION
Gets rid of dirty ‘ol cruft like magic numbers with `boot_mode`. Also makes the command line parsing much cleaner.
